### PR TITLE
Update Comwatt API call

### DIFF
--- a/comwatt_client/client.py
+++ b/comwatt_client/client.py
@@ -252,8 +252,8 @@ class ComwattClient:
 
         """
 
-        url = (f'{self.base_url}/aggregations/device-ts-time-ago?'
-               f'deviceId={device_id}&'
+        url = (f'{self.base_url}/aggregations/time-series?'
+               f'id={device_id}&'
                f'measureKind={measure_kind}&'
                f'aggregationLevel={aggregation_level}&'
                f'aggregationType={aggregation_type}&'
@@ -264,7 +264,7 @@ class ComwattClient:
         if response.status_code == 200:
             return response.json()
         else:
-            raise Exception(f'Error retrieving aggregations: {response.status_code}')
+            raise Exception(f'Error retrieving aggregations: {response.status_code} for url {url}')
 
     def switch_capacity(self, capacity_id, enable):
         """


### PR DESCRIPTION
Fixing: https://github.com/MateoGreil/python-comwatt-client/issues/3

L'ensemble des fonctions de la partie Usage est ok, il semble que seulement l'url et le paramètre id aient été changés côtés Comwatt pour la fonction **get_device_ts_time_ago**.

En tout cas, cette version me trouve bien tous mes appareils. Dans mon test, à partir de Usage, j'ai mis :

```python
devices = client.get_devices(sites[0]['id'])
print(f"Found {len(devices)} devices")

for device in devices:
    device_id = device.get('id')
    device_name = device.get('name', 'Unnamed')

    print(f"Examining device {device_name} (ID: {device_id})")
    
    try:
        time_series_data = client.get_device_ts_time_ago(device_id)
        print(f"Time series data for device {device_id}:\n{time_series_data}\n")
    except Exception as e:
        print(f"Error retrieving time series for {device_name} (ID: {device_id}): {e}")
```

Et les seules erreurs que j'ai surviennent quand device_id est vide, ce qui arrive parfois.